### PR TITLE
Updated pypvwatts to work with NREL PVWatts v5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-    - "2.6"
+    # - "2.6"
     - "2.7"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,15 @@ python:
 
 before_install:
     - pip install requests
+    - pip install python-coveralls
+    - pip install pytest-cov
+    - pip install pytest-flakes
 
 install:
     - python setup.py install
 
 script:
-    - python -m unittest pypvwatts.test
+    - py.test --flake  --cov-report term --cov pypvwatts pypvwatts/test.py
+
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ pypvwatts
 
 [![Build Status](https://travis-ci.org/mpaolino/pypvwatts.svg?branch=master)](https://travis-ci.org/mpaolino/pypvwatts)
 
-A NREL PVWAtts API v4 thin Python wrapper built around requests library.
+A NREL PVWAtts API v5 thin Python wrapper built around requests library.
 
 Developed by <http://renooble.com>.
 
 
 
-PVWatts API v4 Documentation: <http://developer.nrel.gov/docs/solar/pvwatts-v4/>
+PVWatts API v5 Documentation: <http://developer.nrel.gov/docs/solar/pvwatts-v5/>
 
 Python requests library: <http://docs.python-requests.org/en/latest/>
 
@@ -37,20 +37,26 @@ Usage - with class methods
 
 
     >>> from pypvwatts import PVWatts
-    >>> PVWatts.api_key = 'myapikeyHLM6x2In2KmX4fxsTRRBT2r9KfDagJjU'
-    >>> result = PVWatts.request(system_size=4, dataset='tmy2', derate=0.77, lat=40, lon=-105)
+    >>> PVWatts.api_key = 'myapikey'
+    >>> result = PVWatts.request(
+            system_capacity=4, module_type=1, array_type=1,
+            azimuth=190, tilt=30, dataset='tmy2',
+            losses=0.13, lat=40, lon=-105)
     >>> result.ac_annual
-    7607.97607421875    
+    6683.64501953125    
 
 Usage - with instance methods
 -----------------------------
 
 
     >>> from pypvwatts import PVWatts
-    >>> p = PVWatts(api_key='myapikeyHLM6x2In2KmX4fxsTRRBT2r9KfDagJjU')
-    >>> result = p.request(system_size=4, dataset='tmy2', derate=0.77, lat=40, lon=-105)
+    >>> p = PVWatts(api_key='myapikey')
+    >>> result = p.request(
+            system_capacity=4, module_type=1, array_type=1,
+            azimuth=190, tilt=30, dataset='tmy2',
+            losses=0.13, lat=40, lon=-105)
     >>> result.ac_annual
-    7607.97607421875    
+    6683.64501953125    
 
 
 Request parameters and responses
@@ -72,7 +78,10 @@ Raw result data can be queried using the result.raw attribute.
 
 
     >>> from pypvwatts import PVWatts
-    >>> result = PVWatts.request(system_size=4, dataset='tmy2', derate=0.77, lat=40, lon=-105)
+    >>> result = PVWatts.request(
+            system_capacity=4, module_type=1, array_type=1,
+            azimuth=190, tilt=30, dataset='tmy2',
+            losses=0.13, lat=40, lon=-105)
     >>> result.raw
     {u'errors': [u'You have exceeded your rate limit. Try again later or contact us at http://developer.nrel.gov/contact for assistance']}
 
@@ -84,7 +93,10 @@ All API errors are reported via JSON response, using the errors attribute.
 
 
     >>> from pypvwatts import PVWatts
-    >>> result = PVWatts.request(system_size=4, dataset='tmy2', derate=0.77, lat=40, lon=-105)
+    >>> result = PVWatts.request(
+            system_capacity=4, module_type=1, array_type=1,
+            azimuth=190, tilt=30, dataset='tmy2',
+            losses=0.13, lat=40, lon=-105)
     >>> result.errors
     [u'You have exceeded your rate limit. Try again later or contact us at http://developer.nrel.gov/contact for assistance']
 
@@ -103,6 +115,7 @@ Simple tests are provided in test.py. Run them with:
 
 Changelog
 ---------
+2.0.0 - Version is now compatible with PVWatts v5. 2.0.0 is not backwards compatible with 1.2.0. Attributes of the API have changed.
 
 1.2.0 - Fixed proxy handling, now using proxies parameter.
 
@@ -112,4 +125,4 @@ Changelog
 
 1.0.0 - First release
 
-Author: Miguel Paolino <mpaolino@gmail.com> - Copyright <http://renooble.com>
+Author: Miguel Paolino <miguel@renooble.com>, Hannes Hapke <hannes@renooble.com> - Copyright <http://renooble.com>

--- a/pypvwatts/__version__.py
+++ b/pypvwatts/__version__.py
@@ -1,1 +1,1 @@
-VERSION = '1.2.0'
+VERSION = '2.0.0'

--- a/pypvwatts/pypvwatts.py
+++ b/pypvwatts/pypvwatts.py
@@ -21,10 +21,10 @@ class omnimethod(object):
 
 class PVWatts():
     '''
-    A Python wrapper for NREL PVWatts V4.0.0 API
+    A Python wrapper for NREL PVWatts V5.0.0 API
     '''
 
-    PVWATTS_QUERY_URL = 'http://developer.nrel.gov/api/pvwatts/v4.json'
+    PVWATTS_QUERY_URL = 'http://developer.nrel.gov/api/pvwatts/v5.json'
     api_key = 'DEMO_KEY'
 
     def __init__(self, api_key='DEMO_KEY', proxies=None):
@@ -32,17 +32,88 @@ class PVWatts():
         self.proxies = proxies
 
     @omnimethod
-    def validate_system_size(self, system_size):
-        if system_size is None:
+    def validate_system_capacity(self, system_capacity):
+        if system_capacity is None:
             return
 
-        if not isinstance(system_size, (int, long, float)):
-            raise PVWattsValidationError('system_size must be int, long or float')
+        if not isinstance(system_capacity, (int, long, float)):
+            raise PVWattsValidationError(
+                'system_capacity must be int, long or float')
 
-        if not (0.05 <= system_size and system_size <= 500000):
-            raise PVWattsValidationError('system_size must be >= 0.05 and <= 500000')
+        if not (0.05 <= system_capacity and system_capacity <= 500000):
+            raise PVWattsValidationError(
+                'system_capacity must be >= 0.05 and <= 500000')
 
-        return system_size
+        return system_capacity
+
+    @omnimethod
+    def validate_module_type(self, module_type):
+        if module_type is None:
+            return
+
+        if not isinstance(module_type, (int)):
+            raise PVWattsValidationError(
+                'module_type must be int, long or float')
+
+        if module_type not in (0, 1, 2):
+            raise PVWattsValidationError(
+                'module_type must be 0, 1 or 2')
+
+        return module_type
+
+    @omnimethod
+    def validate_losses(self, losses):
+        if losses is None:
+            return
+
+        if not isinstance(losses, (int, long, float)):
+            raise PVWattsValidationError('losses must be int, long or float')
+
+        if not (-5 <= losses and losses <= 99):
+            raise PVWattsValidationError('losses must be >= -5\% and <= 99%')
+
+        return losses
+
+    @omnimethod
+    def validate_array_type(self, array_type):
+        if array_type is None:
+            return
+
+        if not isinstance(array_type, (int)):
+            raise PVWattsValidationError(
+                'array_type must be int, long or float')
+
+        if array_type not in (0, 1, 2, 3, 4):
+            raise PVWattsValidationError(
+                'array_type must be 0, 1, 2, 3 or 4')
+
+        return array_type
+
+    @omnimethod
+    def validate_tilt(self, tilt):
+        if tilt is None:
+            return
+
+        if not isinstance(tilt, (int, long, float)):
+            raise PVWattsValidationError('tilt must be int, long or float')
+
+        if not (0 <= tilt and tilt <= 90):
+            raise PVWattsValidationError('tilt must be >= 0 and <= 90')
+
+        return tilt
+
+    @omnimethod
+    def validate_azimuth(self, azimuth):
+        if azimuth is None:
+            return
+
+        if not isinstance(azimuth, (int, long, float)):
+            raise PVWattsValidationError('azimuth must be int, long or float')
+
+        if not (0 <= azimuth and azimuth <= 360):
+            raise PVWattsValidationError('azimuth must be >= 0 and <= 360')
+
+        return azimuth
 
     @omnimethod
     def validate_lat(self, lat):
@@ -66,7 +137,7 @@ class PVWatts():
             raise PVWattsValidationError('lon must be int, long or float')
 
         if not (-180 <= lon and lon <= 180):
-            raise PVWattsValidationError('lon must be >= -90 and <= 90')
+            raise PVWattsValidationError('lon must be >= -180 and <= 180')
 
         return lon
 
@@ -79,9 +150,23 @@ class PVWatts():
             raise PVWattsValidationError('dataset must be str or unicode')
 
         if dataset not in ('tmy2', 'tmy3', 'intl'):
-            raise PVWattsValidationError('dataset must be \'tmy2\', \'tmy3\' or \'intl\'')
+            raise PVWattsValidationError(
+                'dataset must be \'tmy2\', \'tmy3\' or \'intl\'')
 
         return dataset
+
+    @omnimethod
+    def validate_radius(self, radius):
+        if radius is None:
+            return
+
+        if not isinstance(radius, (int, long, float)):
+            raise PVWattsValidationError('radius must be int, long or float')
+
+        if not (0 <= radius):
+            raise PVWattsValidationError('radius must be >= 0')
+
+        return radius
 
     @omnimethod
     def validate_timeframe(self, timeframe):
@@ -89,100 +174,55 @@ class PVWatts():
             return
 
         if not isinstance(timeframe, (str, unicode)):
-            raise PVWattsValidationError('timeframe must be str or unicode')
+            raise PVWattsValidationError(
+                'timeframe must be str or unicode')
 
         if timeframe not in ('hourly', 'monthly'):
-            raise PVWattsValidationError('dataset must be \'hourly\' or \'monthly\'')
+            raise PVWattsValidationError(
+                'dataset must be \'hourly\' or \'monthly\'')
 
         return timeframe
 
     @omnimethod
-    def validate_azimuth(self, azimuth):
-        if azimuth is None:
+    def validate_dc_ac_ratio(self, dc_ac_ratio):
+        if dc_ac_ratio is None:
             return
 
-        if not isinstance(azimuth, (int, long, float)):
-            raise PVWattsValidationError('azimuth must be int, long or float')
+        if not isinstance(dc_ac_ratio, (int, long, float)):
+            raise PVWattsValidationError(
+                'dc_ac_ratio must be int, long or float')
 
-        if not (0 <= azimuth and azimuth <= 360):
-            raise PVWattsValidationError('azimuth must be >= 0 and <= 360')
+        if not (0 < dc_ac_ratio):
+            raise PVWattsValidationError(
+                'dc_ac_ratio must be positive')
 
-        return azimuth
+        return dc_ac_ratio
 
     @omnimethod
-    def validate_derate(self, derate):
-        if derate is None:
+    def validate_gcr(self, gcr):
+        if gcr is None:
             return
 
-        if not isinstance(derate, (int, long, float)):
-            raise PVWattsValidationError('derate must be int, long or float')
+        if not isinstance(gcr, (int, long, float)):
+            raise PVWattsValidationError('gcr must be int, long or float')
 
-        if not (0 <= derate and derate <= 1):
-            raise PVWattsValidationError('derate must be >= 0 and <= 1')
+        if not (0 <= gcr and gcr <= 3):
+            raise PVWattsValidationError('gcr must be >= 0 and <= 3')
 
-        return derate
+        return gcr
 
     @omnimethod
-    def validate_tilt(self, tilt):
-        if tilt is None:
+    def validate_inv_eff(self, inv_eff):
+        if inv_eff is None:
             return
 
-        if not isinstance(tilt, (int, long, float)):
-            raise PVWattsValidationError('tilt must be int, long or float')
+        if not isinstance(inv_eff, (int, long, float)):
+            raise PVWattsValidationError('inv_eff must be int, long or float')
 
-        return tilt
+        if not (90 <= inv_eff and inv_eff <= 99.5):
+            raise PVWattsValidationError('inv_eff must be >= 90 and <= 99.5')
 
-    @omnimethod
-    def validate_tilt_eq_lat(self, tilt_eq_lat):
-        if tilt_eq_lat is None:
-            return
-
-        if not isinstance(tilt_eq_lat, (int, long, float)):
-            raise PVWattsValidationError('tilt_eq_lat must be int, long or float')
-
-        if tilt_eq_lat not in (0, 1):
-            raise PVWattsValidationError('tilt_eq_lat must be 0 or 1')
-
-        return tilt_eq_lat
-
-    @omnimethod
-    def validate_track_mode(self, track_mode):
-        if track_mode is None:
-            return
-
-        if not isinstance(track_mode, (int, long, float)):
-            raise PVWattsValidationError('track_mode must be int, long or float')
-
-        if track_mode not in (0, 1, 2):
-            raise PVWattsValidationError('track_mode must be 0, 1 or 2')
-
-        return track_mode
-
-    @omnimethod
-    def validate_inoct(self, inoct):
-        if inoct is None:
-            return
-
-        if not isinstance(inoct, (int, long, float)):
-            raise PVWattsValidationError('inoct must be int, long or float')
-
-        if not (30 <= inoct and inoct <= 80):
-            raise PVWattsValidationError('inoct must be >= 30 and <= 80')
-
-        return inoct
-
-    @omnimethod
-    def validate_gamma(self, gamma):
-        if gamma is None:
-            return
-
-        if not isinstance(gamma, (int, long, float)):
-            raise PVWattsValidationError('gamma must be int, long or float')
-
-        if not (-2 <= gamma and gamma <= -0.01):
-            raise PVWattsValidationError('gamma must be >= -2 and <= -0.01')
-
-        return gamma
+        return inv_eff
 
     @property
     def version(self):
@@ -221,27 +261,33 @@ class PVWatts():
         return response.json()
 
     @omnimethod
-    def request(self, format=None, system_size=None, address=None, lat=None,
-                lon=None, file_id=None, dataset='tmy3', timeframe='monthly',
-                azimuth=None, derate=None, tilt=None, tilt_eq_lat=0,
-                track_mode=1, inoct=None, gamma=None, callback=None):
+    def request(self, format=None, system_capacity=None, module_type=0,
+                losses=12, array_type=1, tilt=None, azimuth=None,
+                address=None, lat=None, lon=None, file_id=None, dataset='tmy3',
+                radius=0, timeframe='monthly', dc_ac_ratio=None, gcr=None,
+                inv_eff=None, callback=None):
 
-        params = {'format': format,
-                  'system_size': PVWatts.validate_system_size(system_size),
-                  'address': address,
-                  'lat': PVWatts.validate_lat(lat),
-                  'lon': PVWatts.validate_lon(lon),
-                  'file_id': file_id,
-                  'dataset': PVWatts.validate_dataset(dataset),
-                  'timeframe': PVWatts.validate_timeframe(timeframe),
-                  'azimuth': PVWatts.validate_azimuth(azimuth),
-                  'derate': PVWatts.validate_derate(derate),
-                  'tilt': PVWatts.validate_tilt(tilt),
-                  'tilt_eq_lat': PVWatts.validate_tilt_eq_lat(tilt_eq_lat),
-                  'track_mode': PVWatts.validate_track_mode(track_mode),
-                  'inoct': PVWatts.validate_inoct(inoct),
-                  'gamma': PVWatts.validate_gamma(gamma),
-                  'callback': callback}
+        params = {
+            'format': format,
+            'system_capacity':
+            PVWatts.validate_system_capacity(system_capacity),
+            'module_type': PVWatts.validate_module_type(module_type),
+            'losses': PVWatts.validate_losses(losses),
+            'array_type': PVWatts.validate_array_type(array_type),
+            'tilt': PVWatts.validate_tilt(tilt),
+            'azimuth': PVWatts.validate_azimuth(azimuth),
+            'address': address,
+            'lat': PVWatts.validate_lat(lat),
+            'lon': PVWatts.validate_lon(lon),
+            'file_id': file_id,
+            'dataset': PVWatts.validate_dataset(dataset),
+            'radius': PVWatts.validate_radius(radius),
+            'timeframe': PVWatts.validate_timeframe(timeframe),
+            'dc_ac_ratio': PVWatts.validate_dc_ac_ratio(dc_ac_ratio),
+            'gcr': PVWatts.validate_gcr(gcr),
+            'inv_eff': PVWatts.validate_inv_eff(inv_eff),
+            'callback': callback
+        }
 
         params['api_key'] = PVWatts.api_key
 

--- a/pypvwatts/test.py
+++ b/pypvwatts/test.py
@@ -11,97 +11,101 @@ import json
 
 SAMPLE_RESPONSE = """
 {
-  "station_info": {
-    "tz": -7,
-    "location": "94018",
-    "lon": -105.25,
-    "file_name": "94018.tm2",
-    "city": "BOULDER",
-    "state": "CO",
-    "lat": 40.01666641235352,
-    "elev": 1634
-  },
-  "errors": [
+   "inputs":{
+      "lat":"40",
+      "lon":"-105",
+      "system_capacity":"4",
+      "azimuth":"180",
+      "tilt":"40",
+      "array_type":"1",
+      "module_type":"1",
+      "losses":"10"
+   },
+   "errors":[
 
-  ],
-  "version": "4.0.0",
-  "inputs": {
-    "system_size": "4",
-    "lon": "-105",
-    "derate": "0.77",
-    "dataset": "tmy2",
-    "lat": "40",
-    "api_key": "DEMO_KEY"
-  },
-  "warnings": [
+   ],
+   "warnings":[
 
-  ],
-  "outputs": {
-    "poa_monthly": [
-      137.1923980712891,
-      137.0316772460938,
-      187.4732360839844,
-      182.7943878173828,
-      185.7599792480469,
-      182.4970855712891,
-      187.8779907226562,
-      193.34228515625,
-      187.3993988037109,
-      175.8596649169922,
-      137.8765869140625,
-      132.9652557373047
-    ],
-    "dc_monthly": [
-      468.0147399902344,
-      457.9238891601562,
-      616.0709228515625,
-      581.62548828125,
-      576.5953979492188,
-      551.68603515625,
-      553.3501586914062,
-      569.5568237304688,
-      564.85595703125,
-      550.3904418945312,
-      460.4128112792969,
-      454.1395263671875
-    ],
-    "ac_annual": 5834.35107421875,
-    "solrad_annual": 5.553147792816162,
-    "ac_monthly": [
-      426.7577514648438,
-      417.6890869140625,
-      563.779541015625,
-      529.3705444335938,
-      523.4755249023438,
-      500.5887451171875,
-      502.0051879882812,
-      518.2822875976562,
-      515.994140625,
-      503.0267639160156,
-      420.1042785644531,
-      413.2771606445312
-    ],
-    "solrad_monthly": [
-      4.425561428070068,
-      4.893988609313965,
-      6.047523975372314,
-      6.093146324157715,
-      5.992257595062256,
-      6.083236217498779,
-      6.060580253601074,
-      6.236847877502441,
-      6.246646404266357,
-      5.672892570495605,
-      4.59588623046875,
-      4.289201736450195
-    ]
-  },
-  "ssc_info": {
-    "version": 27,
-    "build": "Unix 64 bit GNU/C++ Jan 10 2013 20:00:07"
-  }
+   ],
+   "version":"1.0.1",
+   "ssc_info":{
+      "version":34,
+      "build":"Unix 64 bit GNU/C++ Aug 18 2014 13:38:36"
+   },
+   "station_info":{
+      "lat":40.016666412353516,
+      "lon":-105.25,
+      "elev":1634.0,
+      "tz":-7.0,
+      "location":"94018",
+      "city":"BOULDER",
+      "state":"CO",
+      "solar_resource_file":"94018.tm2",
+      "distance":21235
+   },
+   "outputs":{
+      "ac_monthly":[
+         474.3351745605469,
+         465.9206237792969,
+         628.4765625,
+         602.564208984375,
+         611.0515747070312,
+         591.2024536132812,
+         596.1395874023438,
+         610.1753540039062,
+         598.2145385742188,
+         574.7982177734375,
+         471.78070068359375,
+         458.9857177734375
+      ],
+      "poa_monthly":[
+         136.04103088378906,
+         136.04443359375,
+         185.7895965576172,
+         181.16891479492188,
+         185.77963256835938,
+         182.52105712890625,
+         187.89971923828125,
+         193.35572814941406,
+         187.40081787109375,
+         175.5979461669922,
+         137.59872436523438,
+         131.25526428222656
+      ],
+      "solrad_monthly":[
+         4.388420581817627,
+         4.858729839324951,
+         5.993212699890137,
+         6.038963794708252,
+         5.992891311645508,
+         6.084035396575928,
+         6.061281204223633,
+         6.237281322479248,
+         6.246694087982178,
+         5.664449691772461,
+         4.5866241455078125,
+         4.2340407371521
+      ],
+      "dc_monthly":[
+         495.09564208984375,
+         487.5823669433594,
+         657.702880859375,
+         629.8565063476562,
+         638.9706420898438,
+         618.6126708984375,
+         623.68994140625,
+         637.5205688476562,
+         624.635009765625,
+         599.9056396484375,
+         492.5662841796875,
+         479.1076354980469
+      ],
+      "ac_annual":6683.64501953125,
+      "solrad_annual":5.5322184562683105
+   }
 }
 """
+
 
 class Test(unittest.TestCase):
     """
@@ -111,66 +115,108 @@ class Test(unittest.TestCase):
     def test_pvwatts_results(self):
         """Test PVWattsResult attrib handling"""
         result = PVWattsResult(json.loads(SAMPLE_RESPONSE))
-        self.assertEqual(result.solrad_annual, 5.553147792816162)
+        self.assertEqual(result.solrad_annual, 5.5322184562683105)
         self.assertEqual(result.station_info['city'], 'BOULDER')
 
     def test_pypvwatts_validation(self):
         """Test pypvwatts validations"""
         self.assertRaises(PVWattsValidationError, PVWatts.request,
-                          system_size='a', dataset='tmy2', derate=0.77,
-                          lat=40, lon=-105, azimuth=0)
+                          system_capacity='a', module_type=1, array_type=1,
+                          azimuth=190, tilt=30,
+                          dataset='tmy2', losses=0.13,
+                          lat=40, lon=-105)
         self.assertRaises(PVWattsValidationError, PVWatts.request,
-                          system_size=4, dataset=1, derate=0.77,
-                          lat=40, lon=-105, azimuth=0)
+                          system_capacity=4, module_type='1', array_type=1,
+                          azimuth=190, tilt=30,
+                          dataset='tmy2', losses=0.13,
+                          lat=40, lon=-105)
         self.assertRaises(PVWattsValidationError, PVWatts.request,
-                          system_size=4, dataset='tmy2', derate=-400,
-                          lat=40, lon=-105, azimuth=0)
+                          system_capacity=4, module_type=1, array_type='1',
+                          azimuth=190, tilt=30,
+                          dataset='tmy2', losses=0.13,
+                          lat=40, lon=-105)
         self.assertRaises(PVWattsValidationError, PVWatts.request,
-                          system_size=4, dataset='tmy2', derate=0.77,
-                          lat=-100, lon=-105, azimuth=0)
+                          system_capacity=4, module_type=1, array_type=1,
+                          azimuth=-190, tilt=30,
+                          dataset='1', losses=0.13,
+                          lat=40, lon=-105)
         self.assertRaises(PVWattsValidationError, PVWatts.request,
-                          system_size=4, dataset='tmy2', derate=0.77,
-                          lat=-10, lon=400, azimuth=0)
+                          system_capacity=4, module_type=1, array_type=1,
+                          azimuth=190, tilt=100,
+                          dataset='1', losses=0.13,
+                          lat=40, lon=-105)
         self.assertRaises(PVWattsValidationError, PVWatts.request,
-                          system_size=4, dataset='tmy2', derate=0.77,
-                          lat=-10, lon=-100, azimuth=-10)
+                          system_capacity=4, module_type=1, array_type=1,
+                          azimuth=190, tilt=30,
+                          dataset='1', losses=0.13,
+                          lat=40, lon=-105)
         self.assertRaises(PVWattsValidationError, PVWatts.request,
-                          system_size=4, dataset='tmy2', derate=0.77,
-                          lat=-10, lon=-100, azimuth=0, timeframe='notvalid')
+                          system_capacity=4, module_type=1, array_type=1,
+                          azimuth=190, tilt=30,
+                          dataset='tmy2', losses=-400,
+                          lat=40, lon=-105)
         self.assertRaises(PVWattsValidationError, PVWatts.request,
-                          system_size=4, dataset='tmy2', derate=0.77,
-                          lat=-10, lon=-100, azimuth=0, tilt='a')
+                          system_capacity=4, module_type=1, array_type=1,
+                          azimuth=190, tilt=30,
+                          dataset='tmy2', losses=0.13,
+                          lat=-100, lon=-105)
         self.assertRaises(PVWattsValidationError, PVWatts.request,
-                          system_size=4, dataset='tmy2', derate=0.77,
-                          lat=-10, lon=-100, azimuth=0, track_mode=6)
+                          system_capacity=4, module_type=1, array_type=1,
+                          azimuth=190, tilt=30,
+                          dataset='tmy2', losses=0.13,
+                          lat=40, lon=400)
         self.assertRaises(PVWattsValidationError, PVWatts.request,
-                          system_size=4, dataset='tmy2', derate=0.77,
-                          lat=-10, lon=-100, azimuth=0, inoct=10)
+                          system_capacity=4, module_type=1, array_type=1,
+                          azimuth=190, tilt=30,
+                          dataset='tmy2', losses=0.13,
+                          lat=40, lon=-105, timeframe='notvalid')
         self.assertRaises(PVWattsValidationError, PVWatts.request,
-                          system_size=4, dataset='tmy2', derate=0.77,
-                          lat=-10, lon=-100, azimuth=0, gamma=-3)
+                          system_capacity=4, module_type=1, array_type=1,
+                          azimuth=190, tilt='a',
+                          dataset='tmy2', losses=0.13,
+                          lat=40, lon=-105)
+        self.assertRaises(PVWattsValidationError, PVWatts.request,
+                          system_capacity=4, module_type=1, array_type=1,
+                          azimuth=190, tilt=30,
+                          dataset='tmy2', losses=0.13,
+                          lat=40, lon=-105, dc_ac_ratio=-10)
+        self.assertRaises(PVWattsValidationError, PVWatts.request,
+                          system_capacity=4, module_type=1, array_type=1,
+                          azimuth=190, tilt=30,
+                          dataset='tmy2', losses=0.13,
+                          lat=40, lon=-105, gcr=10)
+        self.assertRaises(PVWattsValidationError, PVWatts.request,
+                          system_capacity=4, module_type=1, array_type=1,
+                          azimuth=190, tilt=30,
+                          dataset='tmy2', losses=0.13,
+                          lat=40, lon=-105, inv_eff=0)
 
     def test_pypvwatts(self):
         """Test pypvwatts"""
         PVWatts.api_key = 'DEMO_KEY'
-        results = PVWatts.request(system_size=4, dataset='tmy2', derate=0.77,
-                            lat=40, lon=-105)
+        results = PVWatts.request(
+            system_capacity=4, module_type=1, array_type=1,
+            azimuth=190, tilt=30, dataset='tmy2',
+            losses=0.13, lat=40, lon=-105)
+        print results.raw
         self.assert_results(results)
 
     def test_pypvwatts_instance(self):
         """Test pypvwatts instance based searches"""
         p = PVWatts(api_key='DEMO_KEY')
-        results = p.request(system_size=4, dataset='tmy2', derate=0.77, lat=40,
-                           lon=-105)
+        results = p.request(
+            system_capacity=4, module_type=1, array_type=1,
+            azimuth=190, tilt=30, dataset='tmy2',
+            losses=0.13, lat=40, lon=-105)
         self.assert_results(results)
 
     def assert_results(self, results):
-        self.assertEqual(results.ac_annual, 7607.97607421875)
-        self.assertEqual(results.solrad_annual, 7.110589504241943)
+        self.assertEqual(results.ac_annual, 7283.0498046875)
+        self.assertEqual(results.solrad_annual, 5.446694850921631)
         self.assertEqual(results.station_info['city'], 'BOULDER')
-        self.assertIn(784.6525268554688, results.dc_monthly)
-        self.assertIn(252.2440948486328, results.poa_monthly)
-        self.assertIn(8.341022491455078, results.solrad_monthly)
+        self.assertIn(708.9085083007812, results.dc_monthly)
+        self.assertIn(183.11537170410156, results.poa_monthly)
+        self.assertIn(6.103845596313477, results.solrad_monthly)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The API inputs have changed, as well as the output precision was updated by NREL with the release of version 5.
This pull request updates pypvwatts to work with the latest PVWatts API version.

Tests were also updated. All passed. Coveralls added to the travis CI setup.